### PR TITLE
feat: add options to clear and restore workspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 os: linux
-dist: trusty
+dist: focal
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ $ npm install @saithodev/semantic-release-backmerge -D
 
 The plugin can be configured in the [**semantic-release** configuration file](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration):
 
+**Note:** As this plugin will rebase your "develop" branch onto your "master" branch, you may not have any unstaged files in your workspace.
+If you do, you may set the [clearWorkspace](#clearWorkspace) option to stash them and restore them with [restoreWorkspace](#restoreWorkspace) if needed.
+
 ```json
 {
   "plugins": [
@@ -60,6 +63,8 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 | `plugins` | Plugins defined here may stage files to be included in a back-merge commit. See [plugins](#plugins).   |  []  |
 | `message` | The message for the back-merge commit (if files were changed by plugins. See [message](#message).   | `chore(release): Preparations for next release [skip ci]`     |
 | `forcePush` | If set the back-merge will be force-pushed. See [forcePush](#forcePush).   | false |
+| `clearWorkspace` | Whether to stash the current workspace before backmerge. See [clearWorkspace](#clearWorkspace).   | false |
+| `restoreWorkspace` | Restore the stashed workspace after backmerge completed. See [restoreWorkspace](#restoreWorkspace).   | false |
 
 #### `branchName`
 
@@ -108,3 +113,11 @@ If you want to be able to back-merge into the same branch as the branch that was
 Setting this option will force-push the commits from back-merge onto the develop branch.
 
 **Warning:** This will override commits that are not in the develop branch, so make sure that really is what you want!
+
+#### `clearWorkspace`
+
+Setting this option will stash all uncommitted changes from Git workspace before attempting rebase.
+
+#### `restoreWorkspace`
+
+Setting this option will restore the stashed changes after the backmerge completed.

--- a/src/definitions/config.ts
+++ b/src/definitions/config.ts
@@ -1,0 +1,9 @@
+export interface Config {
+    branchName: string;
+    plugins: any;
+    forcePush: boolean;
+    message: string;
+    allowSameBranchMerge: boolean;
+    clearWorkspace: boolean;
+    restoreWorkspace: boolean;
+}

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -37,6 +37,24 @@ export default class Git {
     }
 
     /**
+     * Stash unstaged commits
+     *
+     * @throws {Error} if the commit failed.
+     */
+    async stash() {
+        await execa('git', ['stash'], this.execaOpts);
+    }
+
+    /**
+     * Unstash changes
+     *
+     * @throws {Error} if the commit failed.
+     */
+    async unstash() {
+        await execa('git', ['stash', 'pop'], this.execaOpts);
+    }
+
+    /**
      * Push to the remote repository.
      *
      * @param {String} origin The remote repository URL.

--- a/src/helpers/resolve-config.ts
+++ b/src/helpers/resolve-config.ts
@@ -1,11 +1,15 @@
 import {isNil} from 'lodash';
+import {Config} from "../definitions/config";
 
-export function resolveConfig({branchName, message, plugins, forcePush, allowSameBranchMerge}) {
+export function resolveConfig(config: Partial<Config>): Config {
+    const {branchName, plugins, message, forcePush, allowSameBranchMerge, clearWorkspace, restoreWorkspace} = config
     return {
         branchName: isNil(branchName) ? 'develop' : branchName,
         plugins: isNil(plugins) ? [] : plugins,
         message: message,
         forcePush: isNil(forcePush) ? false : forcePush,
-        allowSameBranchMerge: isNil(allowSameBranchMerge) ? false : allowSameBranchMerge
+        allowSameBranchMerge: isNil(allowSameBranchMerge) ? false : allowSameBranchMerge,
+        clearWorkspace: isNil(clearWorkspace) ? false : clearWorkspace,
+        restoreWorkspace: isNil(restoreWorkspace) ? false : restoreWorkspace
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {verify} from "./verify";
 import {performBackmerge} from "./perform-backmerge";
 import {Context} from "semantic-release";
 import Git from "./helpers/git";
+import {Config} from "./definitions/config";
 
 let verified = false;
 
@@ -12,7 +13,7 @@ let verified = false;
  * @param pluginConfig
  * @param context
  */
-export async function verifyConditions(pluginConfig, context: Context) {
+export async function verifyConditions(pluginConfig: Config, context: Context) {
     const {options} = context;
     if (options.prepare) {
         const preparePlugin = castArray(options.prepare)
@@ -21,6 +22,8 @@ export async function verifyConditions(pluginConfig, context: Context) {
         pluginConfig.plugins = defaultTo(pluginConfig.plugins, preparePlugin.plugins);
         pluginConfig.forcePush = defaultTo(pluginConfig.forcePush, preparePlugin.forcePush);
         pluginConfig.message = defaultTo(pluginConfig.message, preparePlugin.message);
+        pluginConfig.clearWorkspace = defaultTo(pluginConfig.clearWorkspace, preparePlugin.clearWorkspace);
+        pluginConfig.restoreWorkspace = defaultTo(pluginConfig.restoreWorkspace, preparePlugin.restoreWorkspace);
     }
 
     verify(pluginConfig);

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -86,6 +86,24 @@ describe("git", () => {
         );
     });
 
+    it("stash", async () => {
+        await subject.stash();
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['stash'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
+    it("unstash", async () => {
+        await subject.unstash();
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['stash', 'pop'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
     it("getStagedFiles", async () => {
         const execaMock: any = execa;
         execaMock.mockResolvedValueOnce({


### PR DESCRIPTION
Adds new options "clearWorkspace" and "restoreWorkspace" for
stashing Git workspace before rebasing and unstashing it after
rebase completed.

Backmerges into a branch different from master branch are required
to not have uncommitted files!