### PR TITLE
feat: configure backmerge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If you do, you may set the [clearWorkspace](#clearWorkspace) option to stash the
 | Options   | Description                                                                     | Default   |
 |-----------|---------------------------------------------------------------------------------|-----------|
 | `branchName` | The branch where the release is merged into. See [branchName](#branchName).  | develop   |
+| `backmergeStrategy` | How to perform the backmerge. See [backmergeStrategy](#backmergeStrategy).  | rebase   |
 | `plugins` | Plugins defined here may stage files to be included in a back-merge commit. See [plugins](#plugins).   |  []  |
 | `message` | The message for the back-merge commit (if files were changed by plugins. See [message](#message).   | `chore(release): Preparations for next release [skip ci]`     |
 | `forcePush` | If set the back-merge will be force-pushed. See [forcePush](#forcePush).   | false |
@@ -121,3 +122,8 @@ Setting this option will stash all uncommitted changes from Git workspace before
 #### `restoreWorkspace`
 
 Setting this option will restore the stashed changes after the backmerge completed.
+
+#### `backmergeStrategy`
+
+This setting will determine whether the _develop_ branch should be rebased onto _master_ or _master_ should be merged into _develop_.
+Allowed values: rebase (default), merge

--- a/src/definitions/config.ts
+++ b/src/definitions/config.ts
@@ -1,5 +1,8 @@
+export type BackmergeStrategy = "rebase" | "merge";
+
 export interface Config {
     branchName: string;
+    backmergeStrategy: BackmergeStrategy;
     plugins: any;
     forcePush: boolean;
     message: string;

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -130,4 +130,19 @@ export default class Git {
     async rebase(branch: string) {
         await execa('git', ['rebase', `origin/${branch}`], this.execaOpts);
     }
+
+    /**
+     * Rebases the currently checked out branch onto another branch.
+     *
+     * @param {String} branch The branch to rebase onto.
+     * @param {boolean} fromOrigin
+     *
+     * @throws {Error} if the rebase failed.
+     */
+    async merge(branch: string, fromOrigin = true) {
+        if (fromOrigin) {
+            branch = 'origin/' + branch;
+        }
+        await execa('git', ['merge', branch], this.execaOpts);
+    }
 }

--- a/src/helpers/resolve-config.ts
+++ b/src/helpers/resolve-config.ts
@@ -2,9 +2,10 @@ import {isNil} from 'lodash';
 import {Config} from "../definitions/config";
 
 export function resolveConfig(config: Partial<Config>): Config {
-    const {branchName, plugins, message, forcePush, allowSameBranchMerge, clearWorkspace, restoreWorkspace} = config
+    const {branchName, backmergeStrategy, plugins, message, forcePush, allowSameBranchMerge, clearWorkspace, restoreWorkspace} = config
     return {
         branchName: isNil(branchName) ? 'develop' : branchName,
+        backmergeStrategy: isNil(backmergeStrategy) ? 'rebase' : backmergeStrategy,
         plugins: isNil(plugins) ? [] : plugins,
         message: message,
         forcePush: isNil(forcePush) ? false : forcePush,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export async function verifyConditions(pluginConfig: Config, context: Context) {
         const preparePlugin = castArray(options.prepare)
                 .find(config => config.path && config.path === '@saithodev/semantic-release-backmerge') || {};
         pluginConfig.branchName = defaultTo(pluginConfig.branchName, preparePlugin.branchName);
+        pluginConfig.backmergeStrategy = defaultTo(pluginConfig.backmergeStrategy, preparePlugin.backmergeStrategy);
         pluginConfig.plugins = defaultTo(pluginConfig.plugins, preparePlugin.plugins);
         pluginConfig.forcePush = defaultTo(pluginConfig.forcePush, preparePlugin.forcePush);
         pluginConfig.message = defaultTo(pluginConfig.message, preparePlugin.message);

--- a/src/perform-backmerge.ts
+++ b/src/perform-backmerge.ts
@@ -44,7 +44,11 @@ export async function performBackmerge(git: Git, pluginConfig: Partial<Config>, 
         // Branch is detached. Checkout master first to be able to check out other branches
         await git.checkout(masterBranchName);
         await git.checkout(developBranchName);
-        await git.rebase(masterBranchName);
+        if (options.backmergeStrategy === 'merge') {
+            await git.merge(masterBranchName);
+        } else {
+            await git.rebase(masterBranchName);
+        }
     } else {
         await git.checkout(developBranchName);
     }

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -104,6 +104,15 @@ describe("git", () => {
         );
     });
 
+    it("merge", async () => {
+        await subject.merge('master');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
     it("getStagedFiles", async () => {
         const execaMock: any = execa;
         execaMock.mockResolvedValueOnce({


### PR DESCRIPTION
Allows configuring the strategy to be used for backmerge using the new setting `backmergeStrategy`.
Default is "rebase", i.e. develop is rebased onto master.
Another option is "merge", i.e. the master is merged into develop.

Closing #10