### PR TITLE
fix: use repository url from semantic release config

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches: [ master ]
 jobs:
   build:
     name: Lint Code Base
@@ -35,6 +37,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     needs: tests
     steps:
       - uses: actions/checkout@v2
@@ -48,6 +51,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     needs: sonarcloud
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,6 +20,9 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_JSCPD: false # Can not exclude specific file: https://github.com/kucherenko/jscpd/issues/215
+          VALIDATE_TYPESCRIPT_STANDARD: false
+          VALIDATE_MARKDOWN: false
   tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,26 +1,26 @@
 module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-    globals: {
-        'ts-jest': {
-            tsconfig: 'tsconfig.json',
-        },
-    },
-    moduleFileExtensions: [
-        'js',
-        'json',
-        'ts',
-    ],
-    transform: {
-        '^.+\\.(ts|tsx)$': 'ts-jest',
-    },
-    testMatch: [
-        '**/test/**/*.test.ts',
-    ],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json'
+    }
+  },
+  moduleFileExtensions: [
+    'js',
+    'json',
+    'ts'
+  ],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  },
+  testMatch: [
+    '**/test/**/*.test.ts'
+  ],
 
-    // Code Coverage
-    coverageReporters: ['lcovonly', 'text'],
-    collectCoverageFrom: [
-        'src/**/*.ts',
-    ],
-};
+  // Code Coverage
+  coverageReporters: ['lcovonly', 'text'],
+  collectCoverageFrom: [
+    'src/**/*.ts'
+  ]
+}

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -78,8 +78,12 @@ export default class Git {
      *
      * @throws {Error} if the fetch failed.
      */
-    async fetch() {
-        await execa('git', ['fetch'], this.execaOpts);
+    async fetch(url?: string) {
+        const args = ['fetch'];
+        if (url) {
+            args.push(url);
+        }
+        await execa('git', args, this.execaOpts);
     }
 
     /**

--- a/src/perform-backmerge.ts
+++ b/src/perform-backmerge.ts
@@ -31,7 +31,7 @@ export async function performBackmerge(git: Git, pluginConfig: Partial<Config>, 
     await git.configFetchAllRemotes();
 
     // Get latest commits before checking out
-    await git.fetch();
+    await git.fetch(context.options?.repositoryUrl ?? null);
 
     if (options.clearWorkspace) {
         context.logger.log(

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -59,6 +59,12 @@ describe("git", () => {
         expect(execa).toHaveBeenCalledWith('git', ['fetch'], expect.objectContaining(execaOpts));
     });
 
+    it("fetch", async () => {
+        const url = 'https://someUrl';
+        await subject.fetch(url);
+        expect(execa).toHaveBeenCalledWith('git', ['fetch', url], expect.objectContaining(execaOpts));
+    });
+
     it("configFetchAllRemotes", async () => {
         await subject.configFetchAllRemotes();
         expect(execa).toHaveBeenCalledWith(

--- a/test/perform-backmerge.test.ts
+++ b/test/perform-backmerge.test.ts
@@ -24,7 +24,7 @@ describe("perform-backmerge", () => {
                 verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
-                verify(mockedGit.fetch()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('develop')).once();
                 verify(mockedGit.rebase('master')).once();
                 verify(mockedGit.push('my-repo', 'develop', false)).once();
@@ -48,7 +48,7 @@ describe("perform-backmerge", () => {
             .then(() => {
                 verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
-                verify(mockedGit.fetch()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.rebase('master')).never();
                 verify(mockedGit.push('my-repo', 'master', false)).once();
@@ -80,7 +80,7 @@ describe("perform-backmerge", () => {
             .then(() => {
                 verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
-                verify(mockedGit.fetch()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.rebase('master')).never();
                 verify(mockedGit.push('my-repo', 'master', false)).once();
@@ -105,7 +105,7 @@ describe("perform-backmerge", () => {
                 verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
-                verify(mockedGit.fetch()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('develop')).once();
                 verify(mockedGit.rebase('master')).once();
                 verify(mockedGit.push('my-repo', 'develop', false)).once();
@@ -130,7 +130,7 @@ describe("perform-backmerge", () => {
                 verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
-                verify(mockedGit.fetch()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('develop')).once();
                 verify(mockedGit.rebase('master')).once();
                 verify(mockedGit.push('my-repo', 'develop', true)).once();
@@ -164,7 +164,7 @@ describe("perform-backmerge", () => {
         verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
-        verify(mockedGit.fetch()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
         verify(mockedGit.checkout('develop')).once();
         verify(mockedGit.rebase('master')).once();
         verify(mockedGit.commit('my-commit-message')).once();
@@ -197,7 +197,7 @@ describe("perform-backmerge", () => {
         verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
-        verify(mockedGit.fetch()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
 
         const checkoutDevelopAction = mockedGit.checkout('develop');
         verify(mockedGit.stash()).calledBefore(checkoutDevelopAction);
@@ -234,7 +234,7 @@ describe("perform-backmerge", () => {
         verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
-        verify(mockedGit.fetch()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
 
         verify(mockedGit.checkout('develop')).once();
         verify(mockedGit.merge('master', 'none')).once();
@@ -268,7 +268,7 @@ describe("perform-backmerge", () => {
         verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
-        verify(mockedGit.fetch()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
 
         verify(mockedGit.checkout('develop')).once();
         verify(mockedGit.merge('master', 'ours')).once();
@@ -302,7 +302,7 @@ describe("perform-backmerge", () => {
         verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
-        verify(mockedGit.fetch()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
 
         verify(mockedGit.checkout('develop')).once();
         verify(mockedGit.merge('master', 'theirs')).once();
@@ -336,7 +336,7 @@ describe("perform-backmerge", () => {
         verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
-        verify(mockedGit.fetch()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
 
         verify(mockedGit.checkout('develop')).once();
         verify(mockedGit.merge('master', 'ours')).once();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,61 +3,11 @@
     "src/**/*"
   ],
   "compilerOptions": {
-    /* Basic Options */
-    "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": false,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": false                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "target": "es2015",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": false,
+    "esModuleInterop": false
   }
 }


### PR DESCRIPTION
Hi,

I saw that when using `git fetch` the repository url from the configuration is not considered. Therefore I changed the implementation to use the configuration repository url. This has many advantages when you have https for checkout and/or ssh for pushing changes. 