### PR TITLE
fix: resolve checkout issues (#21)

### DIFF
--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -107,7 +107,7 @@ export default class Git {
      * @throws {Error} if the checkout failed.
      */
     async checkout(branch: string) {
-        await execa('git', ['checkout', branch], this.execaOpts);
+        await execa('git', ['checkout', '-B', branch], this.execaOpts);
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export async function verifyConditions(pluginConfig: Config, context: Context) {
  */
 export async function success(pluginConfig, context: Context) {
     if (!verified) {
-        await verify(pluginConfig);
+        verify(pluginConfig);
         verified = true;
     }
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -14,7 +14,7 @@ export function verify(pluginConfig) {
     };
 
     const options = resolveConfig(pluginConfig);
-    const errors = Object.entries(options).reduce(
+    const reducedErrors = Object.entries(options).reduce(
         (errors, [option, value]) =>
             !isNil(value) && VALIDATORS.hasOwnProperty(option) && !VALIDATORS[option](value)
                 ? [...errors, getError(`EINVALID${option.toUpperCase()}`, {[option]: value})]
@@ -22,7 +22,7 @@ export function verify(pluginConfig) {
         []
     );
 
-    if (errors.length > 0) {
-        throw new AggregateError(errors);
+    if (reducedErrors.length > 0) {
+        throw new AggregateError(reducedErrors);
     }
 }

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -87,7 +87,7 @@ describe("git", () => {
         await subject.checkout('develop');
         expect(execa).toHaveBeenCalledWith(
             'git',
-            ['checkout', 'develop'],
+            ['checkout', '-B', 'develop'],
             expect.objectContaining(execaOpts)
         );
     });


### PR DESCRIPTION
After checking out the repository by repositoryUrl the local branches may change so only the master/main branch is available.
This causes subsequent checkouts to fail, since they look for local branches. This issue is resolved by adding the setting `-B` to it.

From `git checkout` documentation:
```
If -B is given, <new_branch> is created if it doesn’t exist; otherwise, it is reset.
```