### PR TITLE
feat: Multi-branch backmerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you do, you may set the [clearWorkspace](#clearWorkspace) option to stash the
     [
       "@saithodev/semantic-release-backmerge",
       {
-        "branchName": "dev",
+        "branches": ["dev"],
         "plugins": [
           [
             "@semantic-release/exec",
@@ -88,7 +88,7 @@ The personal access token in `GITHUB_TOKEN` needs access to the `repo` scope.
 
 | Options   | Description                                                                     | Default   |
 |-----------|---------------------------------------------------------------------------------|-----------|
-| `branchName` | The branch where the release is merged into. See [branchName](#branchName).  | develop   |
+| `branches` | The branches where the release is merged into. See [branches](#branches).  | ['develop']   |
 | `backmergeStrategy` | How to perform the backmerge. See [backmergeStrategy](#backmergeStrategy).  | rebase   |
 | `plugins` | Plugins defined here may stage files to be included in a back-merge commit. See [plugins](#plugins).   |  []  |
 | `message` | The message for the back-merge commit (if files were changed by plugins. See [message](#message).   | `chore(release): Preparations for next release [skip ci]`     |
@@ -97,10 +97,37 @@ The personal access token in `GITHUB_TOKEN` needs access to the `repo` scope.
 | `restoreWorkspace` | Restore the stashed workspace after backmerge completed. See [restoreWorkspace](#restoreWorkspace).   | false |
 | `mergeMode` | Mode for merging (when `backmergeStrategy=merge`). See [mergeMode](#mergeMode).   | none |
 
-#### `branchName`
+#### `branchName` (deprecated)
+
+**Deprecated:** Use [`branches`](#branches) instead (e.g. `branches: ["develop"]`)
 
 Branch name of the branch that should receive the back-merge. If none is given, the default value is used.
 You may use [Lodash template](https://lodash.com/docs#template) variables here. The following variables are available:
+
+| Parameter           | Description                                                                                                                             |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `branch`            | The branch from which the release is done.                                                                                              |
+| `branch.name`       | The branch name.                                                                                                                        |
+| `branch.type`       | The [type of branch](https://github.com/semantic-release/semantic-release/blob/beta/docs/usage/workflow-configuration.md#branch-types). |
+| `branch.channel`    | The distribution channel on which to publish releases from this branch.                                                                 |
+| `branch.range`      | The range of [semantic versions](https://semver.org) to support on this branch.                                                         |
+| `branch.prerelease` | The pre-release detonation to append to [semantic versions](https://semver.org) released from this branch.                              |
+
+#### `branches`
+
+Branch names that should receive the back-merge. If none is given, the default value is used.
+This argument takes a list of branch name strings or objects. A branch object looks like this:
+`{from: "master", to: "dev"}`
+In this example, a release from `master` branch is merged into `dev` branch. With that you can perform conditional backmerges,
+i.e. backmerges that only occur when merged from a certain branch.
+
+Here is an example where all releases will backmerge into `develop` and releases from `next` branch will be backmerged into `staging` as well.
+
+```json
+branches: ["develop", {from: "next", to: "staging"}]
+```
+
+You may use [Lodash template](https://lodash.com/docs#template) variables in branch name strings. The following variables are available:
 
 | Parameter           | Description                                                                                                                             |
 |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------|

--- a/src/definitions/config.ts
+++ b/src/definitions/config.ts
@@ -1,8 +1,11 @@
 export type BackmergeStrategy = "rebase" | "merge";
 export type MergeMode = "none" | "ours" | "theirs";
 
+type BranchType = string|{from: string; to: string}
+
 export interface Config {
     branchName: string;
+    branches: BranchType[];
     backmergeStrategy: BackmergeStrategy;
     plugins: any;
     forcePush: boolean;

--- a/src/definitions/config.ts
+++ b/src/definitions/config.ts
@@ -1,7 +1,8 @@
 export type BackmergeStrategy = "rebase" | "merge";
 export type MergeMode = "none" | "ours" | "theirs";
 
-type BranchType = string|{from: string; to: string}
+export type BranchTypeStruct = {from: string; to: string}
+type BranchType = string|BranchTypeStruct
 
 export interface Config {
     branchName: string;

--- a/src/definitions/errors.ts
+++ b/src/definitions/errors.ts
@@ -10,6 +10,12 @@ export const ERROR_DEFINITIONS = {
             'README.md#branchName'
         )}) option must be a \`String\`. Your configuration for the \`branchName\` option is \`${branchName}\`.`,
     }),
+    EINVALIDBRANCHES: ({branches}) => ({
+        message: 'Invalid `branches` option.',
+        details: `The [branches option](${linkify(
+            'README.md#branches'
+        )}) option must be an \`Array\`. Your configuration for the \`branches\` option is \`${branches}\`.`,
+    }),
     EINVALIDMESSAGE: ({message}) => ({
         message: 'Invalid `message` option.',
         details: `The [message option](${linkify('README.md#message')}) option, if defined, must be a non empty \`String\`.

--- a/src/helpers/resolve-config.ts
+++ b/src/helpers/resolve-config.ts
@@ -2,9 +2,11 @@ import {isNil} from 'lodash';
 import {Config} from "../definitions/config";
 
 export function resolveConfig(config: Partial<Config>): Config {
-    const {branchName, backmergeStrategy, plugins, message, forcePush, allowSameBranchMerge, clearWorkspace, restoreWorkspace, mergeMode} = config
+    const {branchName, branches, backmergeStrategy, plugins, message, forcePush, allowSameBranchMerge, clearWorkspace, restoreWorkspace, mergeMode} = config
     return {
-        branchName: isNil(branchName) ? 'develop' : branchName,
+        // @deprecated branchName – todo: remove with next major release
+        branchName: isNil(branchName) ? null : branchName,
+        branches: isNil(branches) ? ['develop'] : branches,
         backmergeStrategy: isNil(backmergeStrategy) ? 'rebase' : backmergeStrategy,
         plugins: isNil(plugins) ? [] : plugins,
         message: message,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export async function verifyConditions(pluginConfig: Config, context: Context) {
         const preparePlugin = castArray(options.prepare)
                 .find(config => config.path && config.path === '@saithodev/semantic-release-backmerge') || {};
         pluginConfig.branchName = defaultTo(pluginConfig.branchName, preparePlugin.branchName);
+        pluginConfig.branches = defaultTo(pluginConfig.branches, preparePlugin.branches);
         pluginConfig.backmergeStrategy = defaultTo(pluginConfig.backmergeStrategy, preparePlugin.backmergeStrategy);
         pluginConfig.plugins = defaultTo(pluginConfig.plugins, preparePlugin.plugins);
         pluginConfig.forcePush = defaultTo(pluginConfig.forcePush, preparePlugin.forcePush);

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -8,6 +8,7 @@ const isNonEmptyString = (value) => isString(value) && value.trim();
 export function verify(pluginConfig) {
     const VALIDATORS = {
         branchName: isNonEmptyString,
+        branches: isArray,
         message: isNonEmptyString,
         plugins: isArray,
         forcePush: isBoolean,

--- a/test/perform-backmerge.test.ts
+++ b/test/perform-backmerge.test.ts
@@ -21,9 +21,501 @@ describe("perform-backmerge", () => {
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
 
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: ['develop']}, context)
+            .then(() => {
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('develop')).once();
+                verify(mockedGit.rebase('master')).once();
+                verify(mockedGit.push('my-repo', 'develop', false)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("merge into the same branch", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: ['master'], allowSameBranchMerge: true}, context)
+            .then(() => {
+                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.rebase('master')).never();
+                verify(mockedGit.push('my-repo', 'master', false)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("disallow merging into the same branch", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        await performBackmerge(instance(mockedGit), {branches: ['master'], allowSameBranchMerge: false}, context);
+        verify(mockedLogger.error(anyString())).once();
+    });
+
+    it("works with template in branch name", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: ['${branch.name}'], allowSameBranchMerge: true}, context)
+            .then(() => {
+                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.rebase('master')).never();
+                verify(mockedGit.push('my-repo', 'master', false)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("works without plugin definition", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: ['develop']}, context)
+            .then(() => {
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('develop')).once();
+                verify(mockedGit.rebase('master')).once();
+                verify(mockedGit.push('my-repo', 'develop', false)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("with force-push", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: ['develop'], forcePush: true}, context)
+            .then(() => {
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('develop')).once();
+                verify(mockedGit.rebase('master')).once();
+                verify(mockedGit.push('my-repo', 'develop', true)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("if files were changed a commit will be created", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve(['A    file-changed-by-plugin.md'])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                branches: ['develop'],
+                message: 'my-commit-message'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.rebase('master')).once();
+        verify(mockedGit.commit('my-commit-message')).once();
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("stash and unstash", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                branches: ['develop'],
+                clearWorkspace: true,
+                restoreWorkspace: true
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+
+        const checkoutDevelopAction = mockedGit.checkout('develop');
+        verify(mockedGit.stash()).calledBefore(checkoutDevelopAction);
+        verify(checkoutDevelopAction).once();
+        verify(mockedGit.rebase('master')).once();
+
+        const pushAction = mockedGit.push('my-repo', 'develop', false)
+        verify(pushAction).once();
+        verify(mockedGit.unstash()).calledAfter(pushAction);
+    });
+
+    it("merge as backmerge strategy", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                branches: ['develop'],
+                backmergeStrategy: 'merge'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'none')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("checkout mode ours", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                branches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'ours'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'ours')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("merge mode theirs", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                branches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'theirs'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'theirs')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("merge mode ours", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                branches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'ours'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'ours')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+});
+
+describe("perform-backmerge to multiple branches", () => {
+    jest.mock('semantic-release/lib/get-git-auth-url', () => jest.fn((c) => c.options.repositoryUrl));
+
+    it("works with correct configuration", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: ['develop', 'dev']}, context)
+            .then(() => {
+                verify(mockedGit.checkout('master')).twice();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.rebase('master')).twice();
+
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedGit.checkout('develop')).once();
+                verify(mockedGit.push('my-repo', 'develop', false)).once();
+
+                verify(mockedLogger.log('Performing back-merge into branch "dev".')).once();
+                verify(mockedGit.checkout('dev')).once();
+                verify(mockedGit.push('my-repo', 'dev', false)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("works with all-skipped configuration", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: [{from: "main", to: "next"}]}, context)
+            .then(() => {
+                verify(mockedLogger.log('Branch "next" was skipped as release did not originate from branch "main".')).once();
+                verify(mockedGit.push('my-repo', 'next', false)).never();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("abort when merging into the same branch and it's disallowed", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        await performBackmerge(instance(mockedGit), {branches: ['master', 'develop'], allowSameBranchMerge: false}, context);
+        verify(mockedLogger.error('Process aborted due to an error while backmerging a branch.')).once();
+        verify(mockedLogger.error(anyString())).once();
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).never();
+    });
+
+    it("skip conditional backmerge if the release branch does not match the 'from' branch", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: [{from: 'main', to: 'next'}, 'master'], allowSameBranchMerge: true}, context)
+            .then(() => {
+                verify(mockedLogger.log('Branch "next" was skipped as release did not originate from branch "main".')).once();
+                verify(mockedLogger.log('Performing back-merge into branch "next".')).never();
+                verify(mockedGit.push('my-repo', 'next', false)).never();
+
+                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.rebase('master')).never();
+                verify(mockedGit.push('my-repo', 'master', false)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("ignore invalid branch configurations", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: [JSON.parse('{"foo": "bar"}'), 'master'], allowSameBranchMerge: true}, context)
+            .then(() => {
+                verify(mockedLogger.error('Invalid branch configuration found and ignored.')).once();
+
+                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.rebase('master')).never();
+                verify(mockedGit.push('my-repo', 'master', false)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("works with template in 'to' branch name", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: [{from: 'master', to: '${branch.name}'}], allowSameBranchMerge: true}, context)
+            .then(() => {
+                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.rebase('master')).never();
+                verify(mockedGit.push('my-repo', 'master', false)).once();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+});
+
+// todo: remove with next major release when `branchName` is removed
+describe("perform-backmerge with deprecated branchName setting", () => {
+    jest.mock('semantic-release/lib/get-git-auth-url', () => jest.fn((c) => c.options.repositoryUrl));
+
+    it("trigger deprecation notice", async() => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        await performBackmerge(instance(mockedGit), {branchName: 'master', allowSameBranchMerge: false}, context);
+        verify(mockedLogger.log('The property "branchName" is deprecated. Please use "branches" instead: `branches: ["master"]`')).once();
+        verify(mockedLogger.error(anyString())).once();
+    })
+
+    it("works with correct configuration", (done) => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: 'develop'}, context)
             .then(() => {
-                verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -48,7 +540,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: 'master', allowSameBranchMerge: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -62,7 +554,7 @@ describe("perform-backmerge", () => {
     it("disallow merging into the same branch", async () => {
         const mockedGit = mock(Git);
         const mockedLogger = mock(NullLogger);
-        const context = {logger: instance(mockedLogger), branch: {name: 'master'}};
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         await performBackmerge(instance(mockedGit), {branchName: 'master', allowSameBranchMerge: false}, context);
         verify(mockedLogger.error(anyString())).once();
     });
@@ -80,7 +572,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: '${branch.name}', allowSameBranchMerge: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -104,7 +596,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: 'develop'}, context)
             .then(() => {
-                verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -129,7 +621,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: 'develop', forcePush: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -163,7 +655,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -196,7 +688,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -233,7 +725,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -267,7 +759,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -301,7 +793,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -335,7 +827,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Release succeeded. Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -9,6 +9,11 @@ describe("verify", () => {
             verify({branchName: ''});
         }).toThrowError('SemanticReleaseError: Invalid `branchName` option.');
     });
+    it("throws error if branches is not an array", () => {
+        expect(() => {
+            verify({branches: ''});
+        }).toThrowError('SemanticReleaseError: Invalid `branches` option.');
+    });
     it("throws error for empty commit message", () => {
         expect(() => {
             verify({message: ''});


### PR DESCRIPTION
Closing #26 

**Test cases**
* Regular backmerge with deprecated `branchName` setting ✓
* Backmerge into a single branch with default settings `i.e. branches=["develop"]` ✓
* Backmerge into multiple branches with new "branches" setting `branches=["develop", "next"]` ✓
* Conditional backmerge into multiple branches with new "branches" setting `branches=["develop", {from: "master", to: "next"}]` (positive) `branches=["develop", {from: "main", to: "next"}]` (negative) ✓