### PR TITLE
Improve logging

### DIFF
--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -111,10 +111,10 @@ export default class Git {
     }
 
     /**
-     * Get list of files that are included in next commit
+     * Get list of files that are tracked and modified
      * Each entry consists of the status and the file path.
      */
-    getStagedFiles(): Promise<string[]> {
+    getModifiedFiles(): Promise<string[]> {
         return new Promise<string[]>(async (resolve, reject) => {
             execa('git', ['status', '-s', '-uno'], this.execaOpts)
                 .then((result) => {

--- a/src/perform-backmerge.ts
+++ b/src/perform-backmerge.ts
@@ -10,28 +10,28 @@ async function performBackmergeIntoBranch(git: Git, pluginConfig: Partial<Config
         lastRelease,
         nextRelease
     }: any = context;
-    const masterBranchName = branch.name;
-    if (!options.allowSameBranchMerge && developBranchName === masterBranchName) {
+    const releaseBranchName = branch.name;
+    if (!options.allowSameBranchMerge && developBranchName === releaseBranchName) {
         throw new Error(
             'Branch for back-merge is the same as the branch which includes the release. ' +
             'Aborting back-merge workflow.'
         );
     }
 
-    context.logger.log('Performing back-merge into branch "' + developBranchName + '".');
+    context.logger.log('Performing back-merge into develop branch "' + developBranchName + '".');
 
-    if (developBranchName !== masterBranchName) {
+    if (developBranchName !== releaseBranchName) {
         // Branch is detached. Checkout master first to be able to check out other branches
-        context.logger.log('Branch is detached. Checking out master branch.');
-        await git.checkout(masterBranchName);
-        context.logger.log('Checking out develop branch.');
+        context.logger.log(`Branch is detached. Checking out release branch "${releaseBranchName}".`);
+        await git.checkout(releaseBranchName);
+        context.logger.log(`Checking out develop branch "${developBranchName}".`);
         await git.checkout(developBranchName);
         context.logger.log(`Performing backmerge with "${options.backmergeStrategy}" strategy.`);
         if (options.backmergeStrategy === 'merge') {
-            await git.merge(masterBranchName, options.mergeMode);
+            await git.merge(releaseBranchName, options.mergeMode);
         } else {
             try {
-                await git.rebase(masterBranchName)
+                await git.rebase(releaseBranchName)
             } catch (e) {
                 if (e.stderr != null && e.stderr.includes('have unstaged changes')) {
                     context.logger.error('Rebase failed: You have unstaged changes.')
@@ -48,7 +48,7 @@ async function performBackmergeIntoBranch(git: Git, pluginConfig: Partial<Config
             }
         }
     } else {
-        context.logger.log('Checking out develop branch directly.');
+        context.logger.log(`Checking out develop branch "${developBranchName}" directly.`);
         await git.checkout(developBranchName);
     }
 

--- a/src/perform-backmerge.ts
+++ b/src/perform-backmerge.ts
@@ -33,18 +33,18 @@ async function performBackmergeIntoBranch(git: Git, pluginConfig: Partial<Config
             try {
                 await git.rebase(releaseBranchName)
             } catch (e) {
-                if (e.stderr != null && e.stderr.includes('have unstaged changes')) {
-                    context.logger.error('Rebase failed: You have unstaged changes.')
-                    const modifiedFiles = await git.getModifiedFiles();
-                    if (modifiedFiles.length) {
-                        context.logger.error(`${modifiedFiles.length} modified file(s):`)
-                        for (const file of modifiedFiles) {
-                            context.logger.error(file)
-                        }
-                    }
-                    return
+                if (e.stderr == null || !e.stderr.includes('have unstaged changes')) {
+                   throw e
                 }
-                throw e
+                context.logger.error('Rebase failed: You have unstaged changes.')
+                const modifiedFiles = await git.getModifiedFiles()
+                if (modifiedFiles.length) {
+                    context.logger.error(`${modifiedFiles.length} modified file(s):`)
+                    for (const file of modifiedFiles) {
+                        context.logger.error(file)
+                    } 
+                }
+                return
             }
         }
     } else {

--- a/src/perform-backmerge.ts
+++ b/src/perform-backmerge.ts
@@ -38,7 +38,8 @@ async function performBackmergeIntoBranch(git: Git, pluginConfig: Partial<Config
     }
 
     await triggerPluginHooks(options, context);
-    const stagedFiles = await git.getStagedFiles();
+    // in this case there are only staged files
+    const stagedFiles = await git.getModifiedFiles();
     context.logger.log('Found ' + stagedFiles.length + ' staged files for back-merge commit');
     if (stagedFiles.length) {
         for (const file of stagedFiles) {

--- a/test/helpers/git.test.ts
+++ b/test/helpers/git.test.ts
@@ -137,13 +137,13 @@ describe("git", () => {
         );
     });
 
-    it("getStagedFiles", async () => {
+    it("getModifiedFiles", async () => {
         const execaMock: any = execa;
         execaMock.mockResolvedValueOnce({
             stdout: `A  file.txt\nB file2.txt`
         });
 
-        const files = await subject.getStagedFiles();
+        const files = await subject.getModifiedFiles();
         expect(execa).toHaveBeenCalledWith(
             'git',
             ['status', '-s', '-uno'],
@@ -152,12 +152,12 @@ describe("git", () => {
         expect(files).toEqual(['A  file.txt','B file2.txt']);
     });
 
-    it("getStagedFiles fails", (done) => {
+    it("getModifiedFiles fails", (done) => {
         const execaMock: any = execa;
         execaMock.mockRejectedValueOnce({
             stderr: 'An error occurred'
         });
-        subject.getStagedFiles()
+        subject.getModifiedFiles()
             .then(() => done('Error expected'))
             .catch(() => done());
     });

--- a/test/perform-backmerge.test.ts
+++ b/test/perform-backmerge.test.ts
@@ -24,7 +24,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branches: ['develop']}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedLogger.error('Invalid branch configuration found and ignored.')).never();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
@@ -50,7 +50,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), resolveConfig({}), context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedLogger.error('Invalid branch configuration found and ignored.')).never();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
@@ -76,7 +76,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branches: ['master'], allowSameBranchMerge: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -108,7 +108,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branches: ['${branch.name}'], allowSameBranchMerge: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -132,7 +132,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branches: ['develop']}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -157,7 +157,7 @@ describe("perform-backmerge", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branches: ['develop'], forcePush: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -191,7 +191,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -224,7 +224,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -261,7 +261,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -295,7 +295,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -329,7 +329,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -363,7 +363,7 @@ describe("perform-backmerge", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -398,11 +398,11 @@ describe("perform-backmerge to multiple branches", () => {
 
                 verify(mockedLogger.error('Invalid branch configuration found and ignored.')).never();
 
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedGit.checkout('develop')).once();
                 verify(mockedGit.push('my-repo', 'develop', false)).once();
 
-                verify(mockedLogger.log('Performing back-merge into branch "dev".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "dev".')).once();
                 verify(mockedGit.checkout('dev')).once();
                 verify(mockedGit.push('my-repo', 'dev', false)).once();
                 done();
@@ -437,7 +437,7 @@ describe("perform-backmerge to multiple branches", () => {
         await performBackmerge(instance(mockedGit), {branches: ['master', 'develop'], allowSameBranchMerge: false}, context);
         verify(mockedLogger.error('Process aborted due to an error while backmerging a branch.')).once();
         verify(mockedLogger.error(anyString())).once();
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).never();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).never();
     });
 
     it("skip conditional backmerge if the release branch does not match the 'from' branch", (done) => {
@@ -454,10 +454,10 @@ describe("perform-backmerge to multiple branches", () => {
         performBackmerge(instance(mockedGit), {branches: [{from: 'main', to: 'next'}, 'master'], allowSameBranchMerge: true}, context)
             .then(() => {
                 verify(mockedLogger.log('Branch "next" was skipped as release did not originate from branch "main".')).once();
-                verify(mockedLogger.log('Performing back-merge into branch "next".')).never();
+                verify(mockedLogger.log('Performing back-merge into develop branch "next".')).never();
                 verify(mockedGit.push('my-repo', 'next', false)).never();
 
-                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -483,7 +483,7 @@ describe("perform-backmerge to multiple branches", () => {
             .then(() => {
                 verify(mockedLogger.error('Invalid branch configuration found and ignored.')).once();
 
-                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -507,7 +507,7 @@ describe("perform-backmerge to multiple branches", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branches: [{from: 'master', to: '${branch.name}'}], allowSameBranchMerge: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -537,7 +537,7 @@ describe("perform-backmerge with error", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branches: ['develop']}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedLogger.error('Invalid branch configuration found and ignored.')).never();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
@@ -569,7 +569,7 @@ describe("perform-backmerge with error", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branches: ['develop']}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedLogger.error('Invalid branch configuration found and ignored.')).never();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
@@ -610,7 +610,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: 'develop'}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -635,7 +635,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: 'master', allowSameBranchMerge: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -667,7 +667,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: '${branch.name}', allowSameBranchMerge: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "master".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "master".')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
                 verify(mockedGit.checkout('master')).once();
@@ -691,7 +691,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: 'develop'}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -716,7 +716,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
         performBackmerge(instance(mockedGit), {branchName: 'develop', forcePush: true}, context)
             .then(() => {
-                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
                 verify(mockedGit.checkout('master')).once();
                 verify(mockedGit.configFetchAllRemotes()).once();
                 verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -750,7 +750,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -783,7 +783,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -820,7 +820,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -854,7 +854,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -888,7 +888,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();
@@ -922,7 +922,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
             },
             context
         );
-        verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
         verify(mockedGit.checkout('master')).once();
         verify(mockedGit.configFetchAllRemotes()).once();
         verify(mockedGit.fetch(context.options.repositoryUrl)).once();

--- a/test/perform-backmerge.test.ts
+++ b/test/perform-backmerge.test.ts
@@ -519,6 +519,71 @@ describe("perform-backmerge to multiple branches", () => {
     });
 });
 
+describe("perform-backmerge with error", () => {
+    jest.mock('semantic-release/lib/get-git-auth-url', () => jest.fn((c) => c.options.repositoryUrl));
+    it("rebase with unstaged changes", (done) => {
+        class MockError extends Error {
+            stderr: string
+        }
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenThrow({message:'',name:'',stderr:'have unstaged changes'} as MockError);
+        when(mockedGit.getModifiedFiles()).thenReturn(new Promise<string[]>(resolve => resolve(['M testfile'])));
+        when(mockedLogger.error(anyString())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: ['develop']}, context)
+            .then(() => {
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.error('Invalid branch configuration found and ignored.')).never();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('develop')).once();
+                verify(mockedGit.rebase('master')).once();
+                verify(mockedGit.getModifiedFiles()).once();
+                verify(mockedLogger.error('1 modified file(s):')).once();
+                verify(mockedLogger.error('M testfile')).once();
+                verify(mockedGit.push('my-repo', 'develop', false)).never();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+
+    it("rebase with other error", (done) => {
+        class MockError extends Error {
+            stderr: string
+        }
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.rebase(anyString())).thenThrow({message:'',name:'',stderr:'any other error'} as MockError);
+        when(mockedGit.getModifiedFiles()).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}};
+        performBackmerge(instance(mockedGit), {branches: ['develop']}, context)
+            .then(() => {
+                verify(mockedLogger.log('Performing back-merge into branch "develop".')).once();
+                verify(mockedLogger.error('Invalid branch configuration found and ignored.')).never();
+                verify(mockedGit.checkout('master')).once();
+                verify(mockedGit.configFetchAllRemotes()).once();
+                verify(mockedGit.fetch(context.options.repositoryUrl)).once();
+                verify(mockedGit.checkout('develop')).once();
+                verify(mockedGit.rebase('master')).once();
+                verify(mockedGit.getModifiedFiles()).never();
+                verify(mockedGit.push('my-repo', 'develop', false)).never();
+                done();
+            })
+            .catch((error) => done(error));
+    });
+});
+
 // todo: remove with next major release when `branchName` is removed
 describe("perform-backmerge with deprecated branchName setting", () => {
     jest.mock('semantic-release/lib/get-git-auth-url', () => jest.fn((c) => c.options.repositoryUrl));

--- a/test/perform-backmerge.test.ts
+++ b/test/perform-backmerge.test.ts
@@ -16,7 +16,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -42,7 +42,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -68,7 +68,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -100,7 +100,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -124,7 +124,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -149,7 +149,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -174,7 +174,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve(['A    file-changed-by-plugin.md'])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -206,7 +206,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -244,7 +244,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -277,7 +277,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -311,7 +311,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -345,7 +345,7 @@ describe("perform-backmerge", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -383,7 +383,7 @@ describe("perform-backmerge to multiple branches", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -415,7 +415,7 @@ describe("perform-backmerge to multiple branches", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -445,7 +445,7 @@ describe("perform-backmerge to multiple branches", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -473,7 +473,7 @@ describe("perform-backmerge to multiple branches", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -499,7 +499,7 @@ describe("perform-backmerge to multiple branches", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -537,7 +537,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -562,7 +562,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -594,7 +594,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -618,7 +618,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -643,7 +643,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles()).thenResolve([]);
+        when(mockedGit.getModifiedFiles()).thenResolve([]);
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.rebase(anyString())).thenResolve();
         when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
@@ -668,7 +668,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve(['A    file-changed-by-plugin.md'])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -700,7 +700,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -738,7 +738,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -771,7 +771,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -805,7 +805,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();
@@ -839,7 +839,7 @@ describe("perform-backmerge with deprecated branchName setting", () => {
         const mockedLogger = mock(NullLogger);
         when(mockedGit.checkout(anyString())).thenResolve();
         when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getStagedFiles())
+        when(mockedGit.getModifiedFiles())
             .thenReturn(new Promise<string[]>(resolve => resolve([])));
         when(mockedGit.fetch()).thenResolve();
         when(mockedGit.commit(anyString())).thenResolve();


### PR DESCRIPTION
Hi!
I implemented the feature request from https://github.com/saitho/semantic-release-backmerge/issues/30 with the help of its creator https://github.com/kaerbr :)

This pull request contains the following changes:
- Refactor: Rename `getStagedFiles` to `getModifiedFiles`
  - `git status -s -uno` lists all tracked modified files, in the previous use case it is a special case, that they are staged files
- Feature: Log list modified files on failed rebase, if git fails with "unstaged changes"
- Feature: Add actual branch names to log messages
- Refactor: Rename variable `masterBranchName` to `releaseBranchName` and reference it as "release branch" in log messages
  - Because it is the branch from where the release is merged back, so the term "master" could be avoided

Screenshot:
![image](https://user-images.githubusercontent.com/14968844/152536946-b1127a95-04e2-4493-acb6-c098142c51e2.png)


Perhaps you can use some of these suggestions :)

Closes #30 

greetings,
Basti