### PR TITLE
feat(*): add option for fast forwarding during commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The personal access token in `GITHUB_TOKEN` needs access to the `repo` scope.
 | `clearWorkspace` | Whether to stash the current workspace before backmerge. See [clearWorkspace](#clearWorkspace).   | false |
 | `restoreWorkspace` | Restore the stashed workspace after backmerge completed. See [restoreWorkspace](#restoreWorkspace).   | false |
 | `mergeMode` | Mode for merging (when `backmergeStrategy=merge`). See [mergeMode](#mergeMode).   | none |
+| `fastForwardMode` | Fast forwarding option for merging (when `backmergeStrategy=merge`). See [fastForwardMode](#fastForwardMode).   | none |
 
 #### `backmergeBranches`
 
@@ -187,5 +188,21 @@ This setting will be used to determine how merge conflicts are resolved when usi
 Allowed values: none (default), ours, theirs
 
 none = no merge conflict resolve (process will abort on merge conflicts!)
+
 ours = apply changes from _develop_ branch
+
 theirs = apply changes from _master_ branch
+
+#### `fastForwardMode`
+
+This setting will be used to determine the fast forwarding strategy when using the `merge` backmerge strategy.
+
+Allowed values: none (default), ff, no-ff, ff-only
+
+none = default setting which is the same as ff.
+
+ff = when possible resolve the merge as a fast-forward (only update the branch pointer to match the merged branch; do not create a merge commit). When not possible (when the merged-in history is not a descendant of the current history), create a merge commit.
+
+no-ff = create a merge commit in all cases, even when the merge could instead be resolved as a fast-forward.
+
+ff-only = resolve the merge as a fast-forward when possible. When not possible, refuse to merge and exit with a non-zero status.

--- a/src/definitions/config.ts
+++ b/src/definitions/config.ts
@@ -1,5 +1,6 @@
 export type BackmergeStrategy = "rebase" | "merge";
 export type MergeMode = "none" | "ours" | "theirs";
+export type FastForwardMode = "none" | "ff" | "no-ff" | "ff-only"
 
 export type BranchTypeStruct = {from: string; to: string}
 type BranchType = string|BranchTypeStruct
@@ -14,4 +15,5 @@ export interface Config {
     clearWorkspace: boolean;
     restoreWorkspace: boolean;
     mergeMode: MergeMode;
+    fastForwardMode: FastForwardMode;
 }

--- a/src/helpers/git.test.ts
+++ b/src/helpers/git.test.ts
@@ -167,6 +167,33 @@ describe("git", () => {
         );
     });
 
+    it("merge (ours ff)", async () => {
+        await subject.merge('master', "none", 'ff');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '--ff', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
+    it("merge (ours no-ff)", async () => {
+        await subject.merge('master', "none", 'no-ff');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '--no-ff', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
+    it("merge (ours ff-only)", async () => {
+        await subject.merge('master', "none", 'ff-only');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '--ff-only', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
     it("merge (ours)", async () => {
         await subject.merge('master', 'ours');
         expect(execa).toHaveBeenCalledWith(
@@ -176,11 +203,65 @@ describe("git", () => {
         );
     });
 
+    it("merge (ours ff)", async () => {
+        await subject.merge('master', 'ours', 'ff');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '-Xours', '--ff', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
+    it("merge (ours no-ff)", async () => {
+        await subject.merge('master', 'ours', 'no-ff');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '-Xours', '--no-ff', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
+    it("merge (ours ff-only)", async () => {
+        await subject.merge('master', 'ours', 'ff-only');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '-Xours', '--ff-only', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
     it("merge (theirs)", async () => {
         await subject.merge('master', 'theirs');
         expect(execa).toHaveBeenCalledWith(
             'git',
             ['merge', '-Xtheirs', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
+    it("merge (theirs ff)", async () => {
+        await subject.merge('master', 'theirs', 'ff');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '-Xtheirs', '--ff', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
+    it("merge (theirs no-ff)", async () => {
+        await subject.merge('master', 'theirs', 'no-ff');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '-Xtheirs', '--no-ff', 'origin/master'],
+            expect.objectContaining(execaOpts)
+        );
+    });
+
+    it("merge (theirs ff-only)", async () => {
+        await subject.merge('master', 'theirs', 'ff-only');
+        expect(execa).toHaveBeenCalledWith(
+            'git',
+            ['merge', '-Xtheirs', '--ff-only', 'origin/master'],
             expect.objectContaining(execaOpts)
         );
     });

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -1,4 +1,4 @@
-import {MergeMode} from "../definitions/config.js";
+import {FastForwardMode, MergeMode} from "../definitions/config.js";
 import execa, {ExecaReturnValue} from "execa";
 import debugPkg from "debug";
 const debug = debugPkg('semantic-release:backmerge');
@@ -161,17 +161,21 @@ export default class Git {
     }
 
     /**
-     * Rebases the currently checked out branch onto another branch.
+     * Merges the currently checked out branch onto another branch.
      *
      * @param {String} branch The branch to rebase onto.
      * @param {MergeMode} mergeMode
+     * @param {FastForwardMode} fastForwardMode
      *
-     * @throws {Error} if the rebase failed.
+     * @throws {Error} if the merge failed.
      */
-    async merge(branch: string, mergeMode: MergeMode = 'none') {
+    async merge(branch: string, mergeMode: MergeMode = 'none', fastForwardMode: FastForwardMode = "none") {
         const args = ['merge']
         if (mergeMode !== 'none') {
             args.push('-X' + mergeMode)
+        }
+        if (fastForwardMode !== 'none') {
+            args.push('--' + fastForwardMode)
         }
         args.push('origin/' + branch)
         await this.runGitCommand(args);

--- a/src/helpers/resolve-config.ts
+++ b/src/helpers/resolve-config.ts
@@ -3,7 +3,7 @@ const {isNil} = lodash;
 import {Config} from "../definitions/config.js";
 
 export function resolveConfig(config: Partial<Config>): Config {
-    const {backmergeBranches, backmergeStrategy, plugins, message, forcePush, allowSameBranchMerge, clearWorkspace, restoreWorkspace, mergeMode} = config
+    const {backmergeBranches, backmergeStrategy, plugins, message, forcePush, allowSameBranchMerge, clearWorkspace, restoreWorkspace, mergeMode, fastForwardMode} = config
     return {
         backmergeBranches: isNil(backmergeBranches) ? ['develop'] : backmergeBranches,
         backmergeStrategy: isNil(backmergeStrategy) ? 'rebase' : backmergeStrategy,
@@ -14,5 +14,6 @@ export function resolveConfig(config: Partial<Config>): Config {
         clearWorkspace: isNil(clearWorkspace) ? false : clearWorkspace,
         restoreWorkspace: isNil(restoreWorkspace) ? false : restoreWorkspace,
         mergeMode: isNil(mergeMode) ? 'none' : mergeMode,
+        fastForwardMode: isNil(fastForwardMode) ? 'none' : fastForwardMode,
     };
 }

--- a/src/perform-backmerge.test.ts
+++ b/src/perform-backmerge.test.ts
@@ -275,41 +275,7 @@ describe("perform-backmerge", () => {
         verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
 
         verify(mockedGit.checkout('develop')).once();
-        verify(mockedGit.merge('master', 'none')).once();
-
-        verify(mockedGit.push('my-repo', 'develop', false)).once();
-    });
-
-    it("checkout mode ours", async () => {
-        const mockedGit = mock(Git);
-        const mockedLogger = mock(NullLogger);
-        when(mockedGit.checkout(anyString())).thenResolve();
-        when(mockedGit.configFetchAllRemotes()).thenResolve();
-        when(mockedGit.getModifiedFiles())
-            .thenReturn(new Promise<string[]>(resolve => resolve([])));
-        when(mockedGit.fetch()).thenResolve();
-        when(mockedGit.commit(anyString())).thenResolve();
-        when(mockedGit.merge(anyString(), anyString())).thenResolve();
-        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
-
-        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}} as Context;
-
-        await performBackmerge(
-            instance(mockedGit),
-            {
-                backmergeBranches: ['develop'],
-                backmergeStrategy: 'merge',
-                mergeMode: 'ours'
-            },
-            context
-        );
-        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
-        verify(mockedGit.checkout('master')).once();
-        verify(mockedGit.configFetchAllRemotes()).once();
-        verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
-
-        verify(mockedGit.checkout('develop')).once();
-        verify(mockedGit.merge('master', 'ours')).once();
+        verify(mockedGit.merge('master', 'none', 'none')).once();
 
         verify(mockedGit.push('my-repo', 'develop', false)).once();
     });
@@ -343,7 +309,112 @@ describe("perform-backmerge", () => {
         verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
 
         verify(mockedGit.checkout('develop')).once();
-        verify(mockedGit.merge('master', 'theirs')).once();
+        verify(mockedGit.merge('master', 'theirs', 'none')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("merge mode theirs - fast forward default", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getModifiedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}} as Context
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                backmergeBranches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'theirs',
+                fastForwardMode: 'ff'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'theirs', 'ff')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("merge mode theirs - no fast forward", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getModifiedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}} as Context
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                backmergeBranches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'theirs',
+                fastForwardMode: 'no-ff'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'theirs', 'no-ff')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("merge mode theirs - fast forward only", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getModifiedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}} as Context
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                backmergeBranches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'theirs',
+                fastForwardMode: 'ff-only'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'theirs', 'ff-only')).once();
 
         verify(mockedGit.push('my-repo', 'develop', false)).once();
     });
@@ -377,11 +448,117 @@ describe("perform-backmerge", () => {
         verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
 
         verify(mockedGit.checkout('develop')).once();
-        verify(mockedGit.merge('master', 'ours')).once();
+        verify(mockedGit.merge('master', 'ours', 'none')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("merge mode ours - fast forward default", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getModifiedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}} as Context
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                backmergeBranches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'ours',
+                fastForwardMode: 'ff'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'ours', 'ff')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("merge mode ours - no fast forward", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getModifiedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}} as Context
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                backmergeBranches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'ours',
+                fastForwardMode: 'no-ff'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'ours', 'no-ff')).once();
+
+        verify(mockedGit.push('my-repo', 'develop', false)).once();
+    });
+
+    it("merge mode ours - fast forward only", async () => {
+        const mockedGit = mock(Git);
+        const mockedLogger = mock(NullLogger);
+        when(mockedGit.checkout(anyString())).thenResolve();
+        when(mockedGit.configFetchAllRemotes()).thenResolve();
+        when(mockedGit.getModifiedFiles())
+            .thenReturn(new Promise<string[]>(resolve => resolve([])));
+        when(mockedGit.fetch()).thenResolve();
+        when(mockedGit.commit(anyString())).thenResolve();
+        when(mockedGit.merge(anyString(), anyString())).thenResolve();
+        when(mockedGit.push(anyString(), anyString(), anything())).thenResolve();
+
+        const context = {logger: instance(mockedLogger), branch: {name: 'master'}, options: {repositoryUrl: 'my-repo'}} as Context
+
+        await performBackmerge(
+            instance(mockedGit),
+            {
+                backmergeBranches: ['develop'],
+                backmergeStrategy: 'merge',
+                mergeMode: 'ours',
+                fastForwardMode: 'ff-only'
+            },
+            context
+        );
+        verify(mockedLogger.log('Performing back-merge into develop branch "develop".')).once();
+        verify(mockedGit.checkout('master')).once();
+        verify(mockedGit.configFetchAllRemotes()).once();
+        verify(mockedGit.fetch(context.options!.repositoryUrl)).once();
+
+        verify(mockedGit.checkout('develop')).once();
+        verify(mockedGit.merge('master', 'ours', 'ff-only')).once();
 
         verify(mockedGit.push('my-repo', 'develop', false)).once();
     });
 });
+
 describe("perform-backmerge to multiple branches", () => {
     it("works with correct configuration", (done) => {
         const mockedGit = mock(Git);

--- a/src/perform-backmerge.ts
+++ b/src/perform-backmerge.ts
@@ -32,7 +32,7 @@ async function performBackmergeIntoBranch(git: Git, _pluginConfig: Partial<Confi
         await git.checkout(developBranchName);
         context.logger.log(`Performing backmerge with "${options.backmergeStrategy}" strategy.`);
         if (options.backmergeStrategy === 'merge') {
-            await git.merge(releaseBranchName, options.mergeMode);
+            await git.merge(releaseBranchName, options.mergeMode, options.fastForwardMode);
         } else {
             try {
                 await git.rebase(releaseBranchName)


### PR DESCRIPTION
Add new setting "fastForwardMode" to determine if the backmerge commit should be fast forwarded.

none: default setting which is the same as ff.
ff: when possible resolve the merge as a fast-forward (only update the branch pointer to match the merged branch; do not create a merge commit). When not possible (when the merged-in history is not a descendant of the current history), create a merge commit.
no-ff: create a merge commit in all cases, even when the merge could instead be resolved as a fast-forward.
ff-only: resolve the merge as a fast-forward when possible. When not possible, refuse to merge and exit with a non-zero status.

fix #49