### PR TITLE
fix: allow semantic-release >= v22.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "commit": "git-cz"
   },
   "dependencies": {
-    "semantic-release": ">=20.0.0 <22.0.0",
+    "semantic-release": ">=20.0.0 <22.0.0 || >=22.0.3",
     "@semantic-release/error": "^3.0.0",
     "aggregate-error": "^3.1.0",
     "debug": "^4.3.4",


### PR DESCRIPTION
Hey! :wave:

This commit (https://github.com/saitho/semantic-release-backmerge/commit/758caaa1c5e0329b0edee918818be5d62f1711ba) disabled semantic-release v22 for a good reason, as it was broken...

But it seems like that they reverted the change in v22.0.3 (ref: https://github.com/semantic-release/semantic-release/issues/2968#issuecomment-1732013607, https://github.com/semantic-release/semantic-release/releases/tag/v22.0.3).

So it should be safe to allow versions >= v22.0.3?

Thanks! :smile: